### PR TITLE
refactor: Improve E2E test setup for PayPal flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test-db-reset": "dotenv -e .env.test -- prisma db push --force-reset",
     "test-unit": "dotenv -e .env.test -- vitest",
     "test-e2e": "playwright test",
+    "test:e2e:buy-ticket": "playwright test playwright/buy-ticket.test.ts",
     "test-start": "run-s test-db-setup test-unit test-e2e",
     "verify-dbs": "tsx scripts/verify-databases.ts",
     "postinstall": "pnpm generate",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,8 @@
 import { PlaywrightTestConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+// Load .env.test file
+dotenv.config({ path: '.env.test' });
 
 const opts = {
   // launch headless on CI, in browser locally
@@ -19,7 +23,7 @@ const config: PlaywrightTestConfig = {
   },
   retries: process.env.CI ? 3 : 0,
   webServer: {
-    command: process.env.CI ? 'npm run start' : 'npm run dev',
+    command: process.env.CI ? 'pnpm start' : 'pnpm dev',
     reuseExistingServer: Boolean(process.env.TEST_LOCAL === '1'),
     port: 3000,
   },

--- a/playwright/buy-ticket.test.ts
+++ b/playwright/buy-ticket.test.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+// import { execSync } from 'child_process'; // Removed
+import { PrismaClient } from '~/generated/prisma/client'; // Path based on seed.ts
+import { seedSummerFairEvent } from '../prisma/seed'; // Corrected relative path
+
+test.describe('Buy Ticket Flow', () => {
+  test.beforeAll(async () => {
+    console.log('Setting up test database programmatically...');
+    const prisma = new PrismaClient();
+    try {
+      console.log('Clearing existing test data...');
+      // Order of deletion: from models with foreign keys to models they refer to,
+      // or simply children before parents if ON DELETE CASCADE is not reliably set/assumed.
+      await prisma.order.deleteMany({});
+      // Assuming Users are tied to Organizations. If Users can exist without an org or have other dependencies,
+      // their deletion might need to be timed differently or handled with care.
+      // The seed creates users under an organization.
+      await prisma.user.deleteMany({});
+      await prisma.variant.deleteMany({});
+      await prisma.eventExtra.deleteMany({});
+      await prisma.event.deleteMany({});
+      await prisma.organization.deleteMany({});
+      
+      console.log('Existing data cleared. Seeding test event...');
+      await seedSummerFairEvent(prisma);
+      console.log('Database programmatic seeding complete.');
+
+    } catch (error) {
+      console.error('Error during programmatic database setup:', error);
+      // It's important to throw the error to ensure Playwright knows setup failed.
+      throw error; 
+    } finally {
+      await prisma.$disconnect();
+      console.log('Prisma client disconnected after database setup.');
+    }
+  }, /* Optional: Add a timeout for beforeAll if DB operations are very long */ 60000); // e.g., 60 seconds timeout for beforeAll
+
+  test('should allow a user to buy a ticket for an event', async ({ page }) => {
+    const paypalUserEmail = process.env.PAYPAL_USER_EMAIL;
+    const paypalUserPassword = process.env.PAYPAL_USER_PASSWORD;
+
+    if (!paypalUserEmail || !paypalUserPassword) {
+      throw new Error('PayPal sandbox credentials (PAYPAL_USER_EMAIL, PAYPAL_USER_PASSWORD) are not set. Please ensure they are defined in your test environment (e.g., in the .env.test file).');
+    }
+
+    // 1. Navigate to Event Page
+    await page.goto('/');
+    await page.getByRole('link', { name: /Summer fair/i }).click();
+    await expect(page.getByRole('heading', { name: 'Summer fair' })).toBeVisible({ timeout: 10000 });
+
+    // 2. Select Ticket Variant
+    await page.getByRole('combobox', { name: /ticket type/i }).click(); 
+    await page.getByRole('option', { name: /10:00am - 10:15am - £5/i }).click();
+
+    // 3. Initiate PayPal Checkout
+    const payPalButtonSelector = 'div[data-funding-source="paypal"] button';
+    await page.locator(payPalButtonSelector).waitFor({ state: 'visible', timeout: 20000 });
+    await page.locator(payPalButtonSelector).click();
+
+    // 4. Handle PayPal Sandbox Login & Payment
+    let paypalPage = page;
+    try {
+        const popup = await page.waitForEvent('popup', { timeout: 15000 });
+        paypalPage = popup;
+        await paypalPage.waitForLoadState('domcontentloaded', {timeout: 20000});
+    } catch (e) {
+        console.log("No PayPal popup detected, assuming iframe or error. Test will likely fail if login is in a separate window.");
+    }
+    
+    await paypalPage.waitForSelector('input#email', { timeout: 20000 });
+    await paypalPage.locator('input#email').fill(paypalUserEmail);
+    if (await paypalPage.locator('button#btnNext').isVisible({timeout: 5000})) { // Added timeout for isVisible check
+        await paypalPage.locator('button#btnNext').click();
+    }
+    
+    await paypalPage.waitForSelector('input#password', { timeout: 10000 });
+    await paypalPage.locator('input#password').fill(paypalUserPassword);
+    await paypalPage.locator('button#btnLogin').click();
+
+    await paypalPage.waitForSelector('button#payment-submit-btn', { timeout: 20000 });
+    await paypalPage.locator('button#payment-submit-btn').click();
+
+    // 5. Verify Purchase Confirmation
+    await page.waitForURL(/\/[0-9a-fA-F-]+$/, { timeout: 20000 }); 
+    
+    const confirmationMessage = "Thank you, your order is now confirmed!";
+    await expect(page.getByText(confirmationMessage)).toBeVisible({ timeout: 15000 });
+
+    await expect(page.getByText(/Ticket for 10:00am - 10:15am \(x1\)/i)).toBeVisible();
+    await expect(page.getByText(/Order ID:/i)).toBeVisible();
+  });
+});

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -7,10 +7,10 @@ import { Prisma, PrismaClient } from '~/generated/prisma/client';
 
 const prisma = new PrismaClient();
 
-async function main() {
-  const id = 'c0cb00ae-fd1a-45ff-985f-38950f605a56';
-  const firstEvent: Prisma.EventCreateInput = {
-    id: id,
+export async function seedSummerFairEvent(prismaInstance: PrismaClient) {
+  const eventId = 'c0cb00ae-fd1a-45ff-985f-38950f605a56';
+  const summerFairEventData: Prisma.EventCreateInput = {
+    id: eventId,
     title: 'Summer fair',
     text: 'A very summer fair',
     enabled: true,
@@ -86,20 +86,30 @@ async function main() {
       },
     },
   };
-  await prisma.event.upsert({
+
+  await prismaInstance.event.upsert({
     where: {
-      id: firstEvent.id,
+      id: summerFairEventData.id,
     },
-    create: { ...firstEvent },
-    update: {},
+    create: { ...summerFairEventData },
+    update: {}, // No specific update logic, just ensure it exists
   });
+  console.log(`Event "${summerFairEventData.title}" with ID ${eventId} seeded/updated.`);
+}
+
+async function main() {
+  console.log('Starting database seeding...');
+  await seedSummerFairEvent(prisma); // Call the extracted function
+  // If there were other events or generic seeding logic, it would go here.
+  console.log('Database seeding finished.');
 }
 
 main()
   .catch((e) => {
-    console.error(e);
+    console.error('Error during database seeding:', e);
     process.exit(1);
   })
   .finally(async () => {
     await prisma.$disconnect();
+    console.log('Prisma client disconnected.');
   });


### PR DESCRIPTION
This commit refactors the end-to-end test for the ticket purchase flow with PayPal, focusing on improved environment variable handling and database seeding.

Key changes:
- Playwright configuration (`playwright.config.ts`) now uses `dotenv` to load environment variables from `.env.test`. This allows PayPal sandbox credentials (`PAYPAL_USER_EMAIL`, `PAYPAL_USER_PASSWORD`) to be managed in this file for local test runs.
- Database seeding in `playwright/buy-ticket.test.ts` is now programmatic:
    - The `test.beforeAll` hook no longer uses `execSync` to run shell scripts.
    - `prisma/seed.ts` has been refactored to export a `seedSummerFairEvent` function, which encapsulates the creation logic for the specific "Summer fair" event and its related data. The main seed script still uses this function for backward compatibility with `pnpm db-seed`.
    - The Playwright test now imports `PrismaClient` and `seedSummerFairEvent`. It programmatically clears relevant database tables and then calls `seedSummerFairEvent` to ensure a clean and specific data state for the test.
- The error message in `buy-ticket.test.ts` for missing PayPal credentials has been updated to suggest checking `.env.test`.